### PR TITLE
chore: upgrade omniauth from '~> 1.5' to '~> 2.0'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "ksol"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish Gem
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0
+        bundler-cache: true
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.1']
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Continuous Integration
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0
+        bundler-cache: true
+    - name: RuboCop checks
+      run: bundle exec rubocop
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake

--- a/lib/omniauth-scalingo/version.rb
+++ b/lib/omniauth-scalingo/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Scalingo
-    VERSION = "1.0.1"
+    VERSION = "2.0.0"
   end
 end

--- a/omniauth-scalingo.gemspec
+++ b/omniauth-scalingo.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Scalingo::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.5'
+  gem.add_dependency 'omniauth', '~> 2.0'
   gem.add_dependency 'omniauth-oauth2', '>= 1.4.0', '< 2.0'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test'

--- a/omniauth-scalingo.gemspec
+++ b/omniauth-scalingo.gemspec
@@ -2,8 +2,8 @@
 require File.expand_path('../lib/omniauth-scalingo/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Léo Unbekandt"]
-  gem.email         = ["leo@scalingo.com"]
+  gem.authors       = ["Léo Unbekandt", "Kevin Soltysiak"]
+  gem.email         = ["leo@scalingo.com", "kevin@scalingo.com"]
   gem.description   = %q{Official OmniAuth strategy for Scalingo.}
   gem.summary       = %q{Official OmniAuth strategy for Scalingo.}
   gem.homepage      = "https://github.com/Scalingo/omniauth-scalingo"

--- a/omniauth-scalingo.gemspec
+++ b/omniauth-scalingo.gemspec
@@ -9,6 +9,13 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/Scalingo/omniauth-scalingo"
   gem.license       = "MIT"
 
+  gem.metadata = {
+    "bug_tracker_uri" => "https://github.com/Scalingo/omniauth-scalingo/issues",
+    "documentation_uri" => "https://github.com/Scalingo/omniauth-scalingo",
+    "homepage_uri" => "https://github.com/Scalingo/omniauth-scalingo",
+    "source_code_uri" => "https://github.com/Scalingo/omniauth-scalingo",
+  }
+
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Related to the CVE-2015-9284. The fix is in omniauth 2.0.0: https://github.com/omniauth/omniauth/releases/tag/v2.0.0.

I tested this change in dev and it works perfectly :) 

@ksol I may need help to make the GitHub Action publish work